### PR TITLE
Update meta tag

### DIFF
--- a/app/utils/theme-provider.tsx
+++ b/app/utils/theme-provider.tsx
@@ -126,10 +126,7 @@ function NonFlashOfWrongThemeEls({ ssrTheme }: { ssrTheme: boolean }) {
         On the server, "theme" might be `null`, so clientThemeCode ensures that
         this is correct before hydration.
       */}
-      <meta
-        name="color-scheme"
-        content={theme === 'light' ? 'light dark' : 'dark light'}
-      />
+      <meta name="color-scheme" content={theme === 'light' ? 'light' : 'dark'} />
       {/*
         If we know what the theme is from the server then we don't need
         to do fancy tricks prior to hydration to make things match.


### PR DESCRIPTION
Currently the meta tag for setting color-scheme is causing some odd issues with the default brower settings.

Changing the tag to `<meta name="color-scheme" content={theme === 'light' ? 'light' : 'dark'} />` fixes the issue.

related issue: https://github.com/mattstobbs/remix-dark-mode/issues/5